### PR TITLE
Add Malay translation

### DIFF
--- a/src/common/i18n/index.js
+++ b/src/common/i18n/index.js
@@ -3,6 +3,7 @@ import en from './locales/en';
 import th from './locales/th';
 import zh from './locales/zh';
 import ja from './locales/ja';
+import ms from './locales/ms';
 import labels from './../constants/labels';
 import _ from 'lodash';
 
@@ -12,7 +13,8 @@ I18n.translations = {
     en,
     ja,
     zh,
-    th
+    th,
+    ms
 };
 
 const translate = _.mapValues(labels, v => I18n.t(v));

--- a/src/common/i18n/locales/ms.js
+++ b/src/common/i18n/locales/ms.js
@@ -1,0 +1,134 @@
+// Malay (fallback version - standard Malay in Latin script)
+
+import labels from './../../constants/labels';
+
+const t = {}
+
+// Main or Common
+t[labels.songs] = 'Lagu';
+t[labels.albums] = 'Album';
+t[labels.artists] = 'Artis';
+t[labels.events] = 'Acara';
+t[labels.tags] = 'Tag';
+t[labels.seeMore] = 'Lihat lagi';
+t[labels.highlightPVs] = 'PV tersohor';
+t[labels.recentAlbums] = 'Album terbaru atau akan datang';
+t[labels.randomPopularAlbums] = 'Album popular rawak';
+t[labels.upcomingEvent] = 'Acara akan datang';
+t[labels.other] = 'Lain-lain';
+t[labels.info] = 'Maklumat';
+t[labels.detail] = 'Maklumat lanjut';
+
+// Ranking
+t[labels.daily] = 'Harian';
+t[labels.weekly] = 'Mingguan';
+t[labels.monthly] = 'Bulanan';
+t[labels.overall] = 'Keseluruhan';
+
+// Filter
+t[labels.findSong] = 'Cari lagu';
+t[labels.findAlbum] = 'Cari album';
+t[labels.findArtist] = 'Cari artis';
+t[labels.findEvent] = 'Cari acara';
+t[labels.findTag] = 'Cari tag';
+t[labels.findAnything] = 'Cari apa-apa saja';
+t[labels.filter] = 'Tapis';
+t[labels.filterBy] = 'Tapis ikut';
+t[labels.vocalist] = 'Penyanyi';
+t[labels.newlyPublished] = 'BaruTerbit';
+t[labels.newlyAdded] = 'BaruTambah';
+t[labels.popularity] = 'Populariti';
+t[labels.all] = 'semua';
+t[labels.vocaloid] = 'Vocaloid';
+t[labels.utau] = 'UTAU';
+t[labels.songType] = 'Jenis lagu';
+t[labels.originalSong] = 'Lagu asal';
+t[labels.remaster] = 'Terbit semula';
+t[labels.remix] = 'Olah semula';
+t[labels.cover] = 'Lagu cover';
+t[labels.instrumental] = 'Tanpa suara';
+t[labels.mashup] = 'Campuran';
+t[labels.musicPV] = 'PV muzik';
+t[labels.dramaTV] = 'PV drama';
+t[labels.minimumScore] = 'Markah minimum';
+t[labels.sort] = 'Isih';
+t[labels.name] = 'Nama';
+t[labels.publishDate] = 'Tarikh terbit';
+t[labels.additionDate] = 'Tarikh tambah';
+t[labels.favoritedTimes] = 'Jumlah kegenmaran';
+t[labels.ratingScore] = 'Markah rating';
+t[labels.selectArtist] = 'Pilih artis';
+t[labels.selectTag] = 'Pilih tag';
+t[labels.artistType] = 'Jenis artis';
+t[labels.circle] = 'Kalangan';
+t[labels.illustrator] = 'Illustrator';
+t[labels.producer] = 'Penerbit';
+t[labels.additionDate] = 'Tarikh ditambah';
+t[labels.additionDateDesc] = 'Tarikh ditambah (menurun)';
+t[labels.additionDateAsc] = 'Tarikh ditambah (menaik)';
+t[labels.voicebankReleaseDate] = 'Tarikh terbit bank suara';
+t[labels.releaseDate] = 'Tarikh terbit';
+t[labels.songCount] = 'Jumlah lagu';
+t[labels.songRating] = 'Rating lagu keseluruhan';
+t[labels.followerCount] = 'Jumlah pengikut';
+t[labels.discType] = 'Jenis disk';
+t[labels.unspecified] = 'Tidak dinyatakan';
+t[labels.originalAlbum] = 'Album asal';
+t[labels.single] = 'Single';
+t[labels.ep] = 'E.P.';
+t[labels.splitAlbum] = 'Album pisah';
+t[labels.compilation] = 'Kompilasi';
+t[labels.video] = 'Video';
+t[labels.artbook] = 'Buku seni';
+t[labels.game] = 'Permainan';
+t[labels.fanmade] = 'Buatan peminat'
+t[labels.date] = 'Tarikh';
+t[labels.dateRange] = 'Julat tarikh';
+t[labels.from] = 'Dari';
+t[labels.to] = 'Hingga';
+t[labels.category] = 'Kategori';
+t[labels.albumRelease] = 'Tempat terbitan album';
+t[labels.anniversary] = 'Ulang tahun watak';
+t[labels.club] = 'Kelab';
+t[labels.concert] = 'Konsert';
+t[labels.contest] = 'Pertandingan';
+t[labels.convention] = 'Konvensyen';
+t[labels.seriesName] = 'Siri';
+
+// Detail page or field labels
+t[labels.type] = 'Jenis';
+t[labels.favorite] = 'Kegemaran';
+t[labels.share] = 'Kongsi';
+t[labels.originalPVs] = 'PV asal';
+t[labels.lyrics] = 'Lirik';
+t[labels.popularSongs] = 'Lagu popular';
+t[labels.popularAlbums] = 'Album popular';
+t[labels.ads] = 'Iklan / resap silang';
+t[labels.trackList] = 'Senarai lagu';
+t[labels.disc] = 'Disk';
+t[labels.venue] = 'Tempat';
+t[labels.description] = 'Keterangan';
+t[labels.relatedLink] = 'Pautan berkaitan';
+t[labels.setlist] = 'Senarai set';
+t[labels.groupAndLabels] = 'Kumpulan dan label';
+t[labels.illustratedBy] = 'Ilustrasi oleh';
+t[labels.voiceProvider] = 'Penyedia suara';
+t[labels.characterDesigner] = 'Pereka watak';
+t[labels.illustratorOf] = 'Illustrator untuk';
+t[labels.voiceProviderOf] = 'Penyedia suara untuk';
+t[labels.designerOf] = 'Pereka untuk';
+t[labels.duration] = 'Jangka masa';
+t[labels.add] = 'Tambah'
+t[labels.follow] = 'Ikut'
+t[labels.following] = 'Mengikut'
+t[labels.baseVoicebank] = 'Bank suara asas';
+t[labels.series] = 'Siri';
+
+// Menu
+t[labels.favoriteSongs] = 'Lagu kegemaran';
+t[labels.favoriteAlbums] = 'Koleksi';
+t[labels.favoriteArtists] = 'Artis diikut';
+t[labels.settings] = 'Tetapan';
+t[labels.about] = 'Perihal';
+
+export default t;


### PR DESCRIPTION
This pull requests add the main Malay language translation (written with Latin script / Tulisan Rumi).

I'll decide later if I want to include the alternative Malay translation (written with Arabic script / توليسن جاوي) or not, because of compatibility issue and need to see if it have RTL support. This translation will cover the majority of Malay language users anyway (~80%), only the minority is using alternative Arabic script.

Will cover: Malay language users in Malaysia, Singapore, Brunei, the Malay-concentrated areas in Indonesia (eg. Riau), the Malay-minority areas in Philippines, the Cocos (Keeling) Island native people, and anyone who understand Malay language.

Not cover: The indigenous people areas in some places in Malaysia and Brunei, and the Malay-Thai people at southern Thailand (eg. Pattani). This is because they mainly uses the Arabic script Malay language and this pull request only adds the Latin script Malay language.